### PR TITLE
added readme and config updates

### DIFF
--- a/.github/workflows/npm-publish.yml
+++ b/.github/workflows/npm-publish.yml
@@ -1,0 +1,55 @@
+# This workflow will run tests using node and then publish a package to GitHub Packages when a release is created
+# For more information see: https://help.github.com/actions/language-and-framework-guides/publishing-nodejs-packages
+
+name: Node.js Journalista package
+
+on:
+  release:
+    types:
+      - created
+
+jobs:
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 8
+      - run: npm i
+      - run: npm run build
+      - run: npm test
+
+  publish-npm:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 8
+          registry-url: https://registry.npmjs.org/
+      - run: echo "//registry.npmjs.org/:_authToken=${{ secrets.NPM_TOKEN }}" > ~/.npmrc
+      - run: npm i
+      - run: npm run renpack
+      - run: npm run build && npm link
+      - run: npm publish --access public
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.NPM_TOKEN}}
+
+  publish-gpr:
+    needs: build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v2
+      - uses: actions/setup-node@v1
+        with:
+          node-version: 8
+          registry-url: https://npm.pkg.github.com/
+          scope: '@rajat19'
+      - run: echo "//npm.pkg.github.com/:_authToken=${{ secrets.GITHUB_TOKEN }}" > ~/.npmrc
+      - run: npm i
+      - run: npm run build && npm link
+      - run: npm publish
+        env:
+          NODE_AUTH_TOKEN: ${{secrets.GITHUB_TOKEN}}

--- a/package.json
+++ b/package.json
@@ -1,13 +1,15 @@
 {
-  "name": "journalista",
+  "name": "@rajat19/journalista",
   "version": "1.0.0",
   "description": "Personal journal cli app",
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
     "start": "ts-node index.ts",
+    "start:watch": "nodemon --watch src --exec ts-node src/index.ts",
     "lint": "eslint --fix .",
-    "runhash": "ts-node utils/hash.ts"
+    "build": "tsc && shx rm -rf dist/templates && shx cp -r templates dist",
+    "renpack": "ts-node rename-package.ts"
   },
   "engines": {
     "node": ">=8.17.0"
@@ -17,7 +19,7 @@
   },
   "repository": {
     "type": "git",
-    "url": ""
+    "url": "git+https://github.com/rajat19/journalista.git"
   },
   "author": "Rajat Srivastava",
   "license": "MIT",
@@ -34,7 +36,6 @@
     "eslint": "^5.9.0",
     "jshint": "^2.9.5",
     "nodemon": "^2.0.4",
-    "pre-commit": "^1.2.2",
     "shx": "^0.3.2",
     "ts-node": "^9.0.0",
     "typescript": "^4.0.2"

--- a/readme.md
+++ b/readme.md
@@ -1,3 +1,51 @@
-# journalista
+# Journalista
 
 Personal journal cli app
+It is a terminal application to store personal journal log with user management, to be run
+locally and not on cloud. For simplicity considering we could enter only textual content in journal
+data.
+
+## Terminologies
+- User : An independent entity with access to its own journal. Data should not be shared
+between users.
+- Journal : A text log containing multiple entries.
+- Journal Entry : A piece for text accompanied by a timestamp
+
+## Installation (Using npm registries)
+There are two ways to install the cli (Do any one)
+
+- From npm registry
+```bash
+npm install -g journalista
+journalista
+```
+
+- From github registry
+```bash
+npm install -g @rajat19/journalista
+journalista
+```
+
+## How to run this project (if you want to code)
+- Make changes to code
+- Then run following commands 
+```bash
+npm run build && npm link
+journalista
+```
+or for development purposes you can also directly do
+```bash
+npm run start
+```
+
+## What the system does
+1. Allows login/signup using command line
+2. List/Create journals for user -> only authorized users
+
+The system encrypts username/passwords and journals so that these are not visible by anyone just crawling 
+through the repo. Your journals are secure with us.
+
+
+## Publish
+This package uses github actions to publish to both npm as well as github registries
+Check `.github/workflows/npm-publish.yml` file for more details

--- a/rename-package.ts
+++ b/rename-package.ts
@@ -1,0 +1,14 @@
+#!/usr/bin/env node
+
+import * as fs from 'fs';
+const fileName = './package.json';
+const file = require(fileName);
+
+file.name = "journalista";
+const result: string = JSON.stringify(file, null, 2);
+
+fs.writeFile(fileName, result, function writeJSON(err) {
+  if (err) return console.log(err);
+  console.log(result);
+  console.log('writing to ' + fileName);
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,69 @@
+{
+  "compilerOptions": {
+    /* Visit https://aka.ms/tsconfig.json to read more about this file */
+
+    /* Basic Options */
+    // "incremental": true,                   /* Enable incremental compilation */
+    "target": "es5",                          /* Specify ECMAScript target version: 'ES3' (default), 'ES5', 'ES2015', 'ES2016', 'ES2017', 'ES2018', 'ES2019', 'ES2020', or 'ESNEXT'. */
+    "module": "commonjs",                     /* Specify module code generation: 'none', 'commonjs', 'amd', 'system', 'umd', 'es2015', 'es2020', or 'ESNext'. */
+    // "lib": [],                             /* Specify library files to be included in the compilation. */
+    // "allowJs": true,                       /* Allow javascript files to be compiled. */
+    // "checkJs": true,                       /* Report errors in .js files. */
+    // "jsx": "preserve",                     /* Specify JSX code generation: 'preserve', 'react-native', or 'react'. */
+    "declaration": true,                   /* Generates corresponding '.d.ts' file. */
+    // "declarationMap": true,                /* Generates a sourcemap for each corresponding '.d.ts' file. */
+    "sourceMap": true,                     /* Generates corresponding '.map' file. */
+    // "outFile": "./",                       /* Concatenate and emit output to single file. */
+    "outDir": "dist",                        /* Redirect output structure to the directory. */
+    "rootDir": "./",                       /* Specify the root directory of input files. Use to control the output directory structure with --outDir. */
+    // "composite": true,                     /* Enable project compilation */
+    // "tsBuildInfoFile": "./",               /* Specify file to store incremental compilation information */
+    // "removeComments": true,                /* Do not emit comments to output. */
+    // "noEmit": true,                        /* Do not emit outputs. */
+    // "importHelpers": true,                 /* Import emit helpers from 'tslib'. */
+    // "downlevelIteration": true,            /* Provide full support for iterables in 'for-of', spread, and destructuring when targeting 'ES5' or 'ES3'. */
+    // "isolatedModules": true,               /* Transpile each file as a separate module (similar to 'ts.transpileModule'). */
+
+    /* Strict Type-Checking Options */
+    "strict": true,                           /* Enable all strict type-checking options. */
+    // "noImplicitAny": true,                 /* Raise error on expressions and declarations with an implied 'any' type. */
+    // "strictNullChecks": true,              /* Enable strict null checks. */
+    // "strictFunctionTypes": true,           /* Enable strict checking of function types. */
+    // "strictBindCallApply": true,           /* Enable strict 'bind', 'call', and 'apply' methods on functions. */
+    // "strictPropertyInitialization": true,  /* Enable strict checking of property initialization in classes. */
+    // "noImplicitThis": true,                /* Raise error on 'this' expressions with an implied 'any' type. */
+    // "alwaysStrict": true,                  /* Parse in strict mode and emit "use strict" for each source file. */
+
+    /* Additional Checks */
+    // "noUnusedLocals": true,                /* Report errors on unused locals. */
+    // "noUnusedParameters": true,            /* Report errors on unused parameters. */
+    // "noImplicitReturns": true,             /* Report error when not all code paths in function return a value. */
+    // "noFallthroughCasesInSwitch": true,    /* Report errors for fallthrough cases in switch statement. */
+
+    /* Module Resolution Options */
+    // "moduleResolution": "node",            /* Specify module resolution strategy: 'node' (Node.js) or 'classic' (TypeScript pre-1.6). */
+    // "baseUrl": "./",                       /* Base directory to resolve non-absolute module names. */
+    // "paths": {},                           /* A series of entries which re-map imports to lookup locations relative to the 'baseUrl'. */
+    // "rootDirs": [],                        /* List of root folders whose combined content represents the structure of the project at runtime. */
+    // "typeRoots": [],                       /* List of folders to include type definitions from. */
+    // "types": [],                           /* Type declaration files to be included in compilation. */
+    // "allowSyntheticDefaultImports": true,  /* Allow default imports from modules with no default export. This does not affect code emit, just typechecking. */
+    "esModuleInterop": true,                  /* Enables emit interoperability between CommonJS and ES Modules via creation of namespace objects for all imports. Implies 'allowSyntheticDefaultImports'. */
+    // "preserveSymlinks": true,              /* Do not resolve the real path of symlinks. */
+    // "allowUmdGlobalAccess": true,          /* Allow accessing UMD globals from modules. */
+
+    /* Source Map Options */
+    // "sourceRoot": "",                      /* Specify the location where debugger should locate TypeScript files instead of source locations. */
+    // "mapRoot": "",                         /* Specify the location where debugger should locate map files instead of generated locations. */
+    // "inlineSourceMap": true,               /* Emit a single file with source maps instead of having a separate file. */
+    // "inlineSources": true,                 /* Emit the source alongside the sourcemaps within a single file; requires '--inlineSourceMap' or '--sourceMap' to be set. */
+
+    /* Experimental Options */
+    // "experimentalDecorators": true,        /* Enables experimental support for ES7 decorators. */
+    // "emitDecoratorMetadata": true,         /* Enables experimental support for emitting type metadata for decorators. */
+
+    /* Advanced Options */
+    "skipLibCheck": true,                     /* Skip type checking of declaration files. */
+    "forceConsistentCasingInFileNames": true  /* Disallow inconsistently-cased references to the same file. */
+  }
+}


### PR DESCRIPTION
# Journalista

Personal journal cli app
It is a terminal application to store personal journal log with user management, to be run
locally and not on cloud. For simplicity considering we could enter only textual content in journal
data.

## Terminologies
- User : An independent entity with access to its own journal. Data should not be shared
between users.
- Journal : A text log containing multiple entries.
- Journal Entry : A piece for text accompanied by a timestamp

## Installation (Using npm registries)
There are two ways to install the cli (Do any one)

- From npm registry
```bash
npm install -g journalista
journalista
```

- From github registry
```bash
npm install -g @rajat19/journalista
journalista
```

## How to run this project (if you want to code)
- Make changes to code
- Then run following commands 
```bash
npm run build && npm link
journalista
```
or for development purposes you can also directly do
```bash
npm run start
```

## What the system does
1. Allows login/signup using command line
2. List/Create journals for user -> only authorized users

The system encrypts username/passwords and journals so that these are not visible by anyone just crawling 
through the repo. Your journals are secure with us.


## Publish
This package uses github actions to publish to both npm as well as github registries
Check `.github/workflows/npm-publish.yml` file for more details